### PR TITLE
Adding dependency-check plugin configuration to the pom file

### DIFF
--- a/quickstart-java/pom.xml
+++ b/quickstart-java/pom.xml
@@ -9,6 +9,10 @@
   <artifactId>quickstart-java</artifactId>
   <version>1.0-SNAPSHOT</version>
   <name>quickstart-java</name>
+  <properties>
+    <dependencyCheck.skip>true</dependencyCheck.skip>
+    <dependencyCheck.failBuildOnCVSS>9</dependencyCheck.failBuildOnCVSS>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -72,6 +76,21 @@
         <configuration>
           <mainClass>com.salesforce.ps.AppMain</mainClass>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <configuration>
+          <failBuildOnCVSS>${dependencyCheck.failBuildOnCVSS}</failBuildOnCVSS>
+          <skip>${dependencyCheck.skip}</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Adding the configuration for the dependency-check plugin to the java pom file, so we can quickly scan the project.